### PR TITLE
Dropped charles-rest-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ You will need to set the following system properties. **Pay a lot of attention w
   </tr>
   <tr>
     <td>charles.rest.endpoint</td>
-    <td>--domain--/charles-rest/api/notifications</td>
+    <td>**domain**/**charles-rest-context-root**/api/notifications</td>
     <td><b>Mantadory</b>. Rest endpoint from charles-rest<br>where the found notifications should be sent for handling.</td>
   </tr>
   <tr>
     <td>github.auth.token</td>
     <td>string</td>
-    <td><b>Mantadory</b>. Github's agent access token. It should only have permissions to check notifications, star repos and
-    post comments. <b>Do not give full permsions!</b></td>
+    <td><b>Mantadory</b>. Github agent's access token. It should only have permissions to check notifications, star repos and
+    post comments. <b>Do not give full permissions!</b></td>
   </tr>
 </table>
 
@@ -69,13 +69,13 @@ You will need to set the following system properties. **Pay a lot of attention w
   </tr>
   <tr>
     <td>charles.rest.logs.endpoint</td>
-    <td>--domain--/charles-rest/api/logs</td>
+    <td>**domain**/**charles-rest-context-root**/api/logs</td>
     <td><b>Mantadory</b>. Rest endpoint from charles-rest<br>that returns the log of an action.</td>
   </tr>
   <tr>
     <td>github.auth.token</td>
     <td>string</td>
-    <td><b>Mantadory</b>. Github's agent access token. <b>Must be the same as for the EJB checker</b></td>
+    <td><b>Mantadory</b>. Github agent's access token. <b>Must be the same as for the EJB checker</b></td>
   </tr>
   <tr>
     <td>phantomjsExec</td>

--- a/README.md
+++ b/README.md
@@ -52,12 +52,8 @@ You will need to set the following system properties. **Pay a lot of attention w
   <tr>
     <td>github.auth.token</td>
     <td>string</td>
-    <td><b>Mantadory</b>. Github's agent access token</td>
-  </tr>
-  <tr>
-    <td>charles.rest.token</td>
-    <td>string</td>
-    <td><b>Mantadory</b>. Security token <b>agreed upon</b> by the ejb checker and charles-rest</td>
+    <td><b>Mantadory</b>. Github's agent access token. It should only have permissions to check notifications, star repos and
+    post comments. <b>Do not give full permsions!</b></td>
   </tr>
 </table>
 
@@ -77,14 +73,9 @@ You will need to set the following system properties. **Pay a lot of attention w
     <td><b>Mantadory</b>. Rest endpoint from charles-rest<br>that returns the log of an action.</td>
   </tr>
   <tr>
-    <td>charles.rest.token</td>
-    <td>string</td>
-    <td><b>Mantadory</b>. Security token <b>agreed upon</b> by the ejb checker and charles-rest</td>
-  </tr>
-  <tr>
     <td>github.auth.token</td>
     <td>string</td>
-    <td><b>Mantadory</b>. Github's agent access token. <b>The same as for the EJB checker</b></td>
+    <td><b>Mantadory</b>. Github's agent access token. <b>Must be the same as for the EJB checker</b></td>
   </tr>
   <tr>
     <td>phantomjsExec</td>

--- a/charles-github-notifications-ejb/src/test/java/com/amihaiemil/charles/github/GithubNotificationsCheckTestCase.java
+++ b/charles-github-notifications-ejb/src/test/java/com/amihaiemil/charles/github/GithubNotificationsCheckTestCase.java
@@ -24,17 +24,22 @@
  */
 package com.amihaiemil.charles.github;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.json.Json;
 import javax.json.JsonObject;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+
 import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
@@ -92,7 +97,6 @@ public class GithubNotificationsCheckTestCase {
         try {
             System.setProperty("github.auth.token", "githubtoken");
             System.setProperty("charles.rest.endpoint", "restendpointcharles");
-            System.setProperty("charles.rest.token", "chalresresttoken");
             Logger logger = Mockito.mock(Logger.class);
             GithubNotificationsCheck ghnv = new GithubNotificationsCheck(
                 "http://localhost:"+port+"/", logger
@@ -118,7 +122,6 @@ public class GithubNotificationsCheckTestCase {
         try {
             System.setProperty("github.auth.token", "githubtoken");
             System.setProperty("charles.rest.endpoint", "restendpointcharles");
-            System.setProperty("charles.rest.token", "chalresresttoken");
             Logger logger = Mockito.mock(Logger.class);
             GithubNotificationsCheck ghnv = Mockito.spy(
                 new GithubNotificationsCheck(
@@ -290,7 +293,6 @@ public class GithubNotificationsCheckTestCase {
         try {
             System.setProperty("github.auth.token", "githubtoken");
             System.setProperty("charles.rest.endpoint", "restendpointcharles");
-            System.setProperty("charles.rest.token", "chalresresttoken");
             Logger logger = Mockito.mock(Logger.class);
             GithubNotificationsCheck ghnv = new GithubNotificationsCheck(
                 "http://localhost:"+port+"/", logger
@@ -310,7 +312,6 @@ public class GithubNotificationsCheckTestCase {
     public void ioExceptionWhenCheckingNotifications() throws Exception {
         System.setProperty("github.auth.token", "githubtoken");
         System.setProperty("charles.rest.endpoint", "restendpointcharles");
-        System.setProperty("charles.rest.token", "chalresresttoken");
         Logger logger = Mockito.mock(Logger.class);
         GithubNotificationsCheck ghnv = new GithubNotificationsCheck(
             "http://localhost:"+this.port()+"/", logger
@@ -349,24 +350,6 @@ public class GithubNotificationsCheckTestCase {
         ghnv.readNotifications();
         Mockito.verify(logger).error(
             "Missing charles.rest.roken system property! Please specify the REST endpoint where notifications are posted!"
-       );
-    }
-    
-    /**
-     * GithubNotificationsCheck logs an error if the chales rest token is missing.
-     * @throws Exception If something goes wrong.
-     */
-    @Test
-    public void missingCharlesRestToken() throws Exception {
-        System.setProperty("github.auth.token", "githubtoken");
-        System.setProperty("charles.rest.endpoint", "restendpointcharles");
-        Logger logger = Mockito.mock(Logger.class);
-        GithubNotificationsCheck ghnv = new GithubNotificationsCheck(
-            "http://localhost:8080/", logger
-        );
-        ghnv.readNotifications();
-        Mockito.verify(logger).error(
-            "Missing charles.rest.token system property! Please specify it so we can authenticate to restendpointcharles !"
        );
     }
     
@@ -416,6 +399,5 @@ public class GithubNotificationsCheckTestCase {
     public void cleanupSysProps() {
         System.clearProperty("github.auth.token");
         System.clearProperty("charles.rest.endpoint");
-        System.clearProperty("charles.rest.token");
     }
 }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/rest/NotificationsResource.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/rest/NotificationsResource.java
@@ -98,7 +98,7 @@ public class NotificationsResource {
             if(token == null || token.isEmpty()) {
                 return Response.status(HttpURLConnection.HTTP_FORBIDDEN).build();
             } else {
-                String key = System.getProperty("charles.rest.token");
+                String key = System.getProperty("github.auth.token");
                 if(token.equals(key)) {
                     if(startedActionThreads() > 15) {
                         return Response.status(HttpURLConnection.HTTP_UNAVAILABLE).build();


### PR DESCRIPTION
PR for #124 . Dropped unnecessary token. The github access token, which should not have root privileges (and ideally should be changed periodically) is used instead. Also, the github access token should be the same on both sides always.
