### PR TITLE
Actions concurency switched to Async EJB

### DIFF
--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/ActionTaker.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/ActionTaker.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  1)Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *  2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *  3)Neither the name of charles-rest nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.charles.github;
+
+import javax.ejb.Asynchronous;
+import javax.ejb.Stateless;
+
+/**
+ * EJB that takes actions asynchronously.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ *
+ */
+@Stateless
+public class ActionTaker {
+	
+	/**
+	 * Take an action.
+	 * @param action {@link Action}
+	 */
+	@Asynchronous
+    public void take(Action action) {
+    	action.perform();
+    }
+}

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/ActionTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/ActionTestCase.java
@@ -63,21 +63,45 @@ public class ActionTestCase {
     @Test
     public void actionsExecute() throws Exception {
         Language english = (Language)new English();
-        Issue issue1 = this.githubIssue("amihaiemil", "@charlesmike hello");
+        Issue issue1 = this.githubIssue("amihaiemil", "@charlesmike hello there");
         Issue issue2 = this.githubIssue("jeff", "@charlesmike hello");
         Issue issue3 = this.githubIssue("vlad", "@charlesmike hi");
         Issue issue4 = this.githubIssue("marius", "@charlesmike hello");
-        Action ac1 = new Action(issue1);
-        Action ac2 = new Action(issue2);
-        Action ac3 = new Action(issue3);
-        Action ac4 = new Action(issue4);
+        final Action ac1 = new Action(issue1);
+        final Action ac2 = new Action(issue2);
+        final Action ac3 = new Action(issue3);
+        final Action ac4 = new Action(issue4);
         
         final ExecutorService executorService = Executors.newFixedThreadPool(5);
         List<Future> futures = new ArrayList<Future>();
-        futures.add(executorService.submit(ac1));
-        futures.add(executorService.submit(ac2));
-        futures.add(executorService.submit(ac3));
-        futures.add(executorService.submit(ac4));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac1.perform();
+				
+			}
+		}));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac2.perform();
+				
+			}
+		}));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac3.perform();
+				
+			}
+		}));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac4.perform();
+				
+			}
+		}));
 
         for(Future f : futures) {
             assertTrue(f.get()==null);
@@ -87,7 +111,7 @@ public class ActionTestCase {
         List<Comment> commentsWithReply2 = Lists.newArrayList(issue2.comments().iterate());
         List<Comment> commentsWithReply3 = Lists.newArrayList(issue3.comments().iterate());
         List<Comment> commentsWithReply4 = Lists.newArrayList(issue4.comments().iterate());
-        String expectedReply1 = "> @charlesmike hello\n\n" + String.format(english.response("hello.comment"),"amihaiemil");
+        String expectedReply1 = "> @charlesmike hello there\n\n" + String.format(english.response("hello.comment"),"amihaiemil");
         assertTrue(commentsWithReply1.get(1).json().getString("body")
                 .equals(expectedReply1)); //there should be only 2 comments - the command and the reply.
         
@@ -131,13 +155,23 @@ public class ActionTestCase {
             .thenReturn(comments)
             .thenReturn(issue2.comments());
         
-        Action ac1 = new Action(mockedIssue1);
-        Action ac2 = new Action(mockedIssue2);
+        final Action ac1 = new Action(mockedIssue1);
+        final Action ac2 = new Action(mockedIssue2);
         
         final ExecutorService executorService = Executors.newFixedThreadPool(5);
         List<Future> futures = new ArrayList<Future>();
-        futures.add(executorService.submit(ac1));
-        futures.add(executorService.submit(ac2));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac1.perform();
+			}
+		}));
+        futures.add(executorService.submit(new Runnable() {
+			@Override
+			public void run() {
+				ac2.perform();
+			}
+		}));
 
         for(Future f : futures) {
             assertTrue(f.get()==null);
@@ -146,7 +180,7 @@ public class ActionTestCase {
         List<Comment> commentsWithReply1 = Lists.newArrayList(issue1.comments().iterate());
         List<Comment> commentsWithReply2 = Lists.newArrayList(issue2.comments().iterate());
 
-        String expectedStartsWith = "There was an error when processing your command. [Here](/Action_";
+        String expectedStartsWith = "There was an error when processing your command. [Here](/";
         assertTrue(commentsWithReply1.get(1).json().getString("body")
                 .startsWith(expectedStartsWith)); //there should be only 2 comments - the command and the reply.
         

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/ActionTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/ActionTestCase.java
@@ -75,33 +75,30 @@ public class ActionTestCase {
         final ExecutorService executorService = Executors.newFixedThreadPool(5);
         List<Future> futures = new ArrayList<Future>();
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac1.perform();
-				
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac1);
+            }
+        }));
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac2.perform();
-				
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac2);
+            }
+        }));
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac3.perform();
-				
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac3);
+                
+            }
+        }));
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac4.perform();
-				
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac4);                
+            }
+        }));
 
         for(Future f : futures) {
             assertTrue(f.get()==null);
@@ -161,17 +158,17 @@ public class ActionTestCase {
         final ExecutorService executorService = Executors.newFixedThreadPool(5);
         List<Future> futures = new ArrayList<Future>();
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac1.perform();
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac1);
+            }
+        }));
         futures.add(executorService.submit(new Runnable() {
-			@Override
-			public void run() {
-				ac2.perform();
-			}
-		}));
+            @Override
+            public void run() {
+                new ActionTaker().take(ac2);
+            }
+        }));
 
         for(Future f : futures) {
             assertTrue(f.get()==null);

--- a/charles-rest/webapp/WEB-INF/beans.xml
+++ b/charles-rest/webapp/WEB-INF/beans.xml
@@ -1,0 +1,8 @@
+<beans
+	xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+http://java.sun.com/xml/ns/javaee
+http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+</beans>


### PR DESCRIPTION
PR for #125 
Use [Async EJB](http://docs.oracle.com/javaee/6/tutorial/doc/gkkqg.html) do start actions concurently - this way the concurency is in the container's hands as it should be. 

Also adjusted the unit tests for Action, since Action is no longer a runnable backed by a thread. 