### PR TITLE
Delete command and refactoring

### DIFF
--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/Brain.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/Brain.java
@@ -108,6 +108,9 @@ public class Brain {
              case "indexpage":
                  steps = this.stepsForIndex(com, category.language(), true);
                  break;
+             case "deleteindex":
+                 steps = null; //todo finish impelmenting this.
+                 break;
              default:
                  logger.info("Unknwon command!");
                  String unknown = String.format(

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/Command.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/Command.java
@@ -180,4 +180,17 @@ public abstract class Command {
         return this.crepo;
     }
 
+    /**
+     * Returns the elasticsearch index name for this command.
+     * @return String indexname.
+     * @throws IOException If something goes wrong while reading
+     *  the repo json form the Github API.
+     */
+    public String indexName() throws IOException {
+    	JsonObject repo = this.repo().json();
+    	String owner = repo.getJsonObject("owner").getString("login");
+        String name = repo.getString("name");
+        return owner.toLowerCase() + "x" + name.toLowerCase();
+    }
+
 }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/CommandedRepo.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/CommandedRepo.java
@@ -70,6 +70,8 @@ public class CommandedRepo {
      * Returns true if the repository has a gh-pages branch, false otherwise.
      * The result is <b>cached</b> and so the http call to Github API is performed only at the first call.
      * @return true if there is a gh-pages branch, false otherwise.
+     * @throws IOException If an error occurs
+     *  while communicating with the Github API.
      */
     public boolean hasGhPagesBranch() throws IOException {
         try {
@@ -91,17 +93,28 @@ public class CommandedRepo {
             throw new IOException ("Unexpected HTTP status response.", aerr);
         }
     }
-    
+
     /**
      * Get the Json representation of this repo.
      * @return JsonObject repo.
-     * @throws IOException If something goes wrong.
+     * @throws IOException If an error occurs
+     *  while reading the repo from the Github API.
      */
     public JsonObject json() throws IOException {
         if(this.repoJson == null) {
             this.repoJson = this.repo.json();
         }
         return this.repoJson;
+    }
+
+    /**
+     * Get the repo's name.
+     * @return String name.
+     * @throws IOException If an error occurs
+     *  while reading the repo from the Github API.
+     */
+    public String name() throws IOException{
+        return this.json().getString("name");
     }
 
 }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/DeleteIndexCommandCheck.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/DeleteIndexCommandCheck.java
@@ -67,7 +67,7 @@ public class DeleteIndexCommandCheck extends PreconditionCheckStep {
         if(text.contains("`")) {
             String repoToBeDeleted = text.substring(text.indexOf('`') + 1, text.lastIndexOf('`'));
             try {
-                String repoName = com.repo().json().getString("name");
+                String repoName = com.repo().name();
                 passed = repoName.equals(repoToBeDeleted);
             } catch (IOException e) {
                 logger.error("Exception when getting repo's name", e);

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/GhPagesBranchCheck.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/GhPagesBranchCheck.java
@@ -42,7 +42,7 @@ import com.amihaiemil.charles.steps.Step;
 public class GhPagesBranchCheck extends PreconditionCheckStep {
 
     /**
-     * Repository json as returned by the Github API.
+     * Given command.
      */
     private Command com;
     

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/Language.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/Language.java
@@ -79,7 +79,6 @@ abstract class Language {
                 Pattern p = Pattern.compile(formattedRegex);
                 String text = command.json().getString("body");
                 Matcher m = p.matcher(text);
-
                 if(m.matches()) {
                     return new CommandCategory(keyString.split("\\.")[0], this);
                 }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/PageHostedOnGithubCheck.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/PageHostedOnGithubCheck.java
@@ -26,9 +26,7 @@ package com.amihaiemil.charles.github;
 
 import java.io.IOException;
 
-import javax.json.JsonObject;
 import org.slf4j.Logger;
-
 import com.amihaiemil.charles.steps.PreconditionCheckStep;
 import com.amihaiemil.charles.steps.Step;
 
@@ -78,14 +76,14 @@ public class PageHostedOnGithubCheck extends PreconditionCheckStep {
     @Override
     public void perform() {
         try {
-            JsonObject repo = com.repo().json();
-            String owner = repo.getJsonObject("owner").getString("login");
+            CommandedRepo repo = com.repo();
+            String owner = repo.json().getJsonObject("owner").getString("login");
             String expDomain;
-            logger.info("Checking if the page belongs to the repo " + owner + "/" + repo.getString("name"));
+            logger.info("Checking if the page belongs to the repo " + owner + "/" + repo.name());
             logger.info("Page link: " + this.link);
             boolean ghPagesBranch = com.repo().hasGhPagesBranch();
             if (ghPagesBranch) {
-                expDomain = owner + ".github.io/" + repo.getString("name");
+                expDomain = owner + ".github.io/" + repo.name();
                 logger.info("The repo has a gh-pages branch so the page link has to start with " + expDomain);
             } else {
                 expDomain = owner + ".github.io";

--- a/charles-rest/src/main/java/com/amihaiemil/charles/github/RepoForkCheck.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/github/RepoForkCheck.java
@@ -77,7 +77,7 @@ public class RepoForkCheck extends PreconditionCheckStep {
             logger.warn("Repository should NOT be a fork!");
             this.onFalse().perform();
         } else {
-            logger.info("Repository is not a fort - Ok!");
+            logger.info("Repository is not a fork - Ok!");
             this.onTrue().perform();
         }
     }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/steps/DeleteIndex.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/steps/DeleteIndex.java
@@ -25,7 +25,10 @@
 package com.amihaiemil.charles.steps;
 
 import java.io.IOException;
+
 import org.slf4j.Logger;
+
+import com.amihaiemil.charles.aws.AmazonEsRepository;
 import com.amihaiemil.charles.github.Command;
 
 /**
@@ -47,33 +50,28 @@ public class DeleteIndex  extends IntermediaryStep {
      */
     private Logger logger;
 
-
     /**
      * Constructor.
      * @param com Command
      * @param logger The action's logger
      * @param next The next step to take
      */
-    public DeleteIndex(
-        Command com, Logger logger, Step next
-    ) {
+    public DeleteIndex(Command com, Logger logger, Step next) {
         super(next);
         this.com = com;
         this.logger = logger;
     }
-
+    
     @Override
     public void perform() {
-    	this.logger.info("Starting index deletion...");
+        this.logger.info("Starting index deletion...");
         try {
-            String indexName = com.indexName();
-            logger.info(indexName);
-            //todo delete logic here...
+            new AmazonEsRepository(com.indexName()).deleteIndex();
         } catch (IOException e) {
-        	 logger.error("Exception while deleting the indx!", e);
-             throw new IllegalStateException("Exception while deleting the indx!" , e);
+            logger.error("Exception while deleting the index!", e);
+            throw new IllegalStateException("Exception while deleting the index!" , e);
         }
-        this.logger.info("The index was successfully removed!");
+        this.logger.info("Index successfully deleted!");
         this.next().perform();
     }
 

--- a/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexPage.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexPage.java
@@ -61,9 +61,7 @@ public class IndexPage extends IndexStep {
      * @param logger Logger.
      * @param next Next step to take.
      */
-    public IndexPage(
-        Command com, Logger logger, Step next
-    ) {
+    public IndexPage(Command com, Logger logger, Step next) {
         super(next);
         this.com = com;
         this.logger = logger;
@@ -72,11 +70,15 @@ public class IndexPage extends IndexStep {
     @Override
     public void perform() {
 	    String link = this.getLink();
+	    logger.info("Indexing page " + link + " ...");
     	try {
+    	    logger.info("Crawling the page...");
             WebPage snapshot = new SnapshotWebPage(
                 new LiveWebPage(this.phantomJsDriver(), link)
             );
+    	    logger.info("Page crawled. Sending to aws...");
             new AmazonEsRepository(this.com.indexName()).export(Arrays.asList(snapshot));
+    	    logger.info("Page successfully sent to aws!");
         } catch (DataExportException | IOException | RuntimeException e) {
             logger.error("Exception while indexing the page " + link, e);
             throw new IllegalStateException("Exception while indexing the page" + link, e);

--- a/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexSite.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexSite.java
@@ -90,10 +90,9 @@ public class IndexSite extends IndexStep {
         } else {
             siteIndexUrl = "http://" + repoName;
         }
-        String indexName = com.authorLogin() + "x" + repoName;
         WebCrawl siteCrawl = new GraphCrawl(
             siteIndexUrl, this.phantomJsDriver(), new IgnoredPatterns(),
-            new AmazonEsRepository(indexName.toLowerCase()), 20
+            new AmazonEsRepository(this.com.indexName()), 20
         );
         return siteCrawl;
     }

--- a/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexSite.java
+++ b/charles-rest/src/main/java/com/amihaiemil/charles/steps/IndexSite.java
@@ -53,16 +53,13 @@ public class IndexSite extends IndexStep {
      */
     private Logger logger;
 
-
     /**
      * Constructor.
      * @param com Command
      * @param logger The action's logger
      * @param next The next step to take
      */
-    public IndexSite(
-        Command com, Logger logger, Step next
-    ) {
+    public IndexSite(Command com, Logger logger, Step next) {
         super(next);
         this.com = com;
         this.logger = logger;
@@ -71,7 +68,9 @@ public class IndexSite extends IndexStep {
     @Override
     public void perform() {
         try {
+        	logger.info("Starting to index the whole site...");
             this.graphCrawl().crawl();
+        	logger.info("Indexing finished successfully!");
         } catch (
             DataExportException |
             IOException |
@@ -82,14 +81,17 @@ public class IndexSite extends IndexStep {
         }
         this.next().perform();
     }
+
     public WebCrawl graphCrawl() throws IOException {
-        String repoName = com.repo().json().getString("name");
+        String repoName = this.com.repo().name();
         String siteIndexUrl;
         if(com.repo().hasGhPagesBranch()) {
             siteIndexUrl = "http://" + com.authorLogin() + ".github.io/" + repoName;
         } else {
             siteIndexUrl = "http://" + repoName;
         }
+        logger.info("Graph-crawling, starting from " + siteIndexUrl
+        + " .The website will be crawled as a graph, going in-depth from the index page.");
         WebCrawl siteCrawl = new GraphCrawl(
             siteIndexUrl, this.phantomJsDriver(), new IgnoredPatterns(),
             new AmazonEsRepository(this.com.indexName()), 20

--- a/charles-rest/src/main/resources/commands_en.properties
+++ b/charles-rest/src/main/resources/commands_en.properties
@@ -5,4 +5,4 @@ indexsite.command=^%s[ ,]+(please index|pls index|index please|index pls|index)[
 
 indexpage.command=^%s[ ,]+(index \\[this\\] *\\(.+\\) page|please index \\[this\\] *\\(.+\\) page|pls index \\[this\\] *\\(.+\\) page)[ \\?,\\.;!]*$
 
-deleteindex.command=^%s[ ,]+(delete \S+ index ( pls| please)*)$
+deleteindex.command=^%s[ ,]+(delete \S+ index (pls|please)*)$

--- a/charles-rest/src/main/resources/commands_en.properties
+++ b/charles-rest/src/main/resources/commands_en.properties
@@ -5,4 +5,4 @@ indexsite.command=^%s[ ,]+(please index|pls index|index please|index pls|index)[
 
 indexpage.command=^%s[ ,]+(index \\[this\\] *\\(.+\\) page|please index \\[this\\] *\\(.+\\) page|pls index \\[this\\] *\\(.+\\) page)[ \\?,\\.;!]*$
 
-deleteindex.command=^%s[ ,]+(delete \S+ index)$
+deleteindex.command=^%s[ ,]+(delete \S+ index ( pls| please)*)$

--- a/charles-rest/src/main/resources/commands_en.properties
+++ b/charles-rest/src/main/resources/commands_en.properties
@@ -4,3 +4,5 @@ hello.command=^%s[ ,]+(hi|hello|how are you|how do you do|who are you|what are y
 indexsite.command=^%s[ ,]+(please index|pls index|index please|index pls|index)[ \\?,\\.;!]*$
 
 indexpage.command=^%s[ ,]+(index \\[this\\] *\\(.+\\) page|please index \\[this\\] *\\(.+\\) page|pls index \\[this\\] *\\(.+\\) page)[ \\?,\\.;!]*$
+
+deleteindex.command=^%s[ ,]+(delete \S+ index)$

--- a/charles-rest/src/main/resources/responses_en.properties
+++ b/charles-rest/src/main/resources/responses_en.properties
@@ -18,7 +18,7 @@ denied.badlink.comment=@%s the given page does not seem to belong to the website
                     Make sure that the link starts with ``http://`` or ``https://`` followed by\
                      ``yourusername.github.io/...`` Do not use the CNAME or any other link, even if it redirects to\
                      a page from this repo. \n\n \ If this condition is met and it still doesn't work please open an issue [here]\
-                    (https://github.com/amihaiemil/charles-github-ejb/issues).
+                    (https://github.com/opencharles/charles-github-ejb/issues/new).
 
 denied.deleteindex.comment=@%s the repository's name in a delete command has to be between single back apostrophes.\n\
                            and it has to match the actual reponame exactly (case sensitive) \n\n\
@@ -31,4 +31,11 @@ index.finished.comment=@%s Index command executed successfully! \n \
                          &lt;script src=&quot;#&quot;&gt;%s&lt;/script&gt; \n\n \
                          See [logs](%s) for more details. \n \
                          If you notice any inexplicable errors, please open an issue \
-                         <a href="https://github.com/amihaiemil/charles-github-ejb">here</a>
+                         [here](https://github.com/opencharles/charles-github-ejb/issues/new)
+
+deleteindex.finished.comment=@%s the `%s` index was successfully deleted. \n\
+                              Don't forget to remove the script form your website since the search will not work anymore.\n\
+                              See [logs](%s) for details.\n\n\
+                              If you can spare a minute, please consider opening an issue [here](https://github.com/opencharles/charles-github-ejb/issues/new),\
+                              let us know why you stopped using this service, what you didn't like and what we could improve. Thanks!
+                         

--- a/charles-rest/src/main/resources/responses_en.properties
+++ b/charles-rest/src/main/resources/responses_en.properties
@@ -20,6 +20,10 @@ denied.badlink.comment=@%s the given page does not seem to belong to the website
                      a page from this repo. \n\n \ If this condition is met and it still doesn't work please open an issue [here]\
                     (https://github.com/amihaiemil/charles-github-ejb/issues).
 
+denied.deleteindex.comment=@%s the repository's name in a delete command has to be between single back apostrophes.\n\
+                           and it has to match the actual reponame exactly (case sensitive) \n\n\
+                           A valid delete command here is ``@%s delete `%s` index``.
+
 step.failure.comment=@%s Some steps failed when precessing your command. See [logs](%s) for details.
 
 index.finished.comment=@%s Index command executed successfully! \n \

--- a/charles-rest/src/main/resources/responses_en.properties
+++ b/charles-rest/src/main/resources/responses_en.properties
@@ -1,5 +1,6 @@
-hello.comment=Hi, @%s! I can help you index your Github-hosted website, provided that the repository name respects \
-              the format ``owner.github.io`` (or has a ``gh-pages`` branch) and the command is given by the repo's owner. 
+hello.comment=Hi @%s! I can help you index your Github-hosted website, provided that the repository name respects \
+              the format ``owner.github.io`` (or has a ``gh-pages`` branch) and the command is given by the repo's owner.\n\n\
+              More on commands [here](http://charles.amihaiemil.com/doc.html#commands).
 index.start.comment=@%s thank you for the command, the indexing process started just now. I will let you know of the outcome \
                shortly. In the meantime, you can check the logs [here](%s).
 

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/BrainTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/BrainTestCase.java
@@ -136,7 +136,8 @@ public class BrainTestCase {
         Mockito.when(english.response("denied.commander.comment")).thenReturn("denied commander!");
         Mockito.when(english.response("denied.name.comment")).thenReturn("bad repo!!");
         Mockito.when(english.response("denied.deleteindex.comment")).thenReturn("delete denied!");
-        
+        Mockito.when(english.response("deleteindex.finished.comment")).thenReturn("index deleted!");
+
         Mockito.when(english.categorize(com)
         ).thenReturn(new CommandCategory("deleteindex", english));
         

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/BrainTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/BrainTestCase.java
@@ -116,7 +116,34 @@ public class BrainTestCase {
         Brain br = new Brain(Mockito.mock(Logger.class), Mockito.mock(LogsLocation.class), Arrays.asList(english));
         Steps steps = br.understand(com);
         assertTrue(steps != null);
-        assertTrue(steps.getStepsToPerform() instanceof PreconditionCheckStep);
+        assertTrue(steps.getStepsToPerform() instanceof PageHostedOnGithubCheck);
+    }
+    
+    /**
+     * {@link Brain} can undestand a deleteindex command.
+     * @throws Exception if something goes wrong.
+     */
+    @Test
+    public void understandsDeleteIndexCommand() throws Exception {
+        Command com = this.mockCommand();
+        
+        Language english = Mockito.mock(English.class);
+        Mockito.when(english.response("step.failure.comment")).thenReturn("failure on step");
+        Mockito.when(english.response("index.start.comment")).thenReturn("index start!");
+        Mockito.when(english.response("index.finished.comment")).thenReturn("index finished!");
+        Mockito.when(english.response("denied.badlink.comment")).thenReturn("bad link!");
+        Mockito.when(english.response("denied.fork.comment")).thenReturn("repo is a fork!");
+        Mockito.when(english.response("denied.commander.comment")).thenReturn("denied commander!");
+        Mockito.when(english.response("denied.name.comment")).thenReturn("bad repo!!");
+        Mockito.when(english.response("denied.deleteindex.comment")).thenReturn("delete denied!");
+        
+        Mockito.when(english.categorize(com)
+        ).thenReturn(new CommandCategory("deleteindex", english));
+        
+        Brain br = new Brain(Mockito.mock(Logger.class), Mockito.mock(LogsLocation.class), Arrays.asList(english));
+        Steps steps = br.understand(com);
+        assertTrue(steps != null);
+        assertTrue(steps.getStepsToPerform() instanceof DeleteIndexCommandCheck);
     }
     
     /**

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/CommandedRepoTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/CommandedRepoTestCase.java
@@ -158,9 +158,8 @@ public class CommandedRepoTestCase {
         MkGithub gh = new MkGithub("amihaiemil");
         Repo rep = gh.repos().create(new RepoCreate("charlesrepo", false));
         CommandedRepo crepo = new CommandedRepo(rep);
-        
         JsonObject repoJson = crepo.json();
-        assertTrue(repoJson.getString("name").equals("charlesrepo"));
+        assertTrue(crepo.name().equals("charlesrepo"));
         assertTrue(repoJson.getString("private").equals("false"));
 
         JsonObject repoFromCache = crepo.json();

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/DeleteIndexCommandCheckTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/DeleteIndexCommandCheckTestCase.java
@@ -22,66 +22,101 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.amihaiemil.charles.github;
 
 import javax.json.Json;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
-
 import com.amihaiemil.charles.steps.Step;
 
 /**
- * Unit tests for {@link GhPagesBranchCheck}
+ * Unit tests for {@link DeleteIndexCommandCheck}
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  *
  */
-public class GhPagesBranchCheckTestCase {
+public class DeleteIndexCommandCheckTestCase {
 
     /**
-     * GhPagesBranchCheck can tell if the gh-pages branch exists in the repo.
+     * DeleteIndexCommandCheck can see that given reponame equals the actual reponame
      * @throws Exception If something goes wrong.
      */
     @Test
-    public void ghpagesBranchExists() throws Exception {
+    public void repoNameEqualsActual() throws Exception {
         Command com = Mockito.mock(Command.class);
+        Mockito.when(com.json()).thenReturn(
+            Json.createObjectBuilder()
+                .add("body", "@charlesmike delete `eva` index")
+                .build()
+        );
         CommandedRepo crepo = Mockito.mock(CommandedRepo.class);
-        Mockito.when(crepo.hasGhPagesBranch()).thenReturn(true);
+        Mockito.when(crepo.name()).thenReturn("eva");
         Mockito.when(com.repo()).thenReturn(crepo);
+
         Step onTrue = Mockito.mock(Step.class);
         Mockito.doNothing().when(onTrue).perform();
         Step onFalse = Mockito.mock(Step.class);
         Mockito.doThrow(new IllegalStateException("This step should not have been executed!")).when(onFalse).perform();
 
-        GhPagesBranchCheck gpc = new GhPagesBranchCheck(
+        DeleteIndexCommandCheck dc = new DeleteIndexCommandCheck(
             com, Mockito.mock(Logger.class), onTrue, onFalse
         );
-        gpc.perform();
+        dc.perform();
     }
 
     /**
-     * GhPagesBranchCheck can tell if the gh-pages branch does not exist in the repo.
+     * DeleteIndexCommandCheck can see that given reponame does not equal the actual reponame
      * @throws Exception If something goes wrong.
      */
     @Test
-    public void ghpagesBranchDoesntExist() throws Exception {
+    public void repoNameNotEqualsActual() throws Exception {
         Command com = Mockito.mock(Command.class);
+        Mockito.when(com.json()).thenReturn(
+            Json.createObjectBuilder()
+                .add("body", "@charlesmike delete `evamisspelled` index")
+                .build()
+        );
         CommandedRepo crepo = Mockito.mock(CommandedRepo.class);
-        Mockito.when(crepo.hasGhPagesBranch()).thenReturn(false);
+        Mockito.when(crepo.name()).thenReturn("eva");
         Mockito.when(com.repo()).thenReturn(crepo);
+
         Step onTrue = Mockito.mock(Step.class);
         Mockito.doThrow(new IllegalStateException("This step should not have been executed!")).when(onTrue).perform();
         Step onFalse = Mockito.mock(Step.class);
         Mockito.doNothing().when(onFalse).perform();
 
-        GhPagesBranchCheck gpc = new GhPagesBranchCheck(
+        DeleteIndexCommandCheck dc = new DeleteIndexCommandCheck(
             com, Mockito.mock(Logger.class), onTrue, onFalse
         );
-        gpc.perform();
+        dc.perform();
     }
 
+    /**
+     * DeleteIndexCommandCheck goes onFalse if the given repoName is not between back-apostrophes.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void missingBackApostrophes() throws Exception {
+        Command com = Mockito.mock(Command.class);
+        Mockito.when(com.json()).thenReturn(
+            Json.createObjectBuilder()
+                .add("body", "@charlesmike delete eva index")
+                .build()
+        );
+        CommandedRepo crepo = Mockito.mock(CommandedRepo.class);
+        Mockito.when(crepo.name()).thenReturn("eva");
+        Mockito.when(com.repo()).thenReturn(crepo);
+
+        Step onTrue = Mockito.mock(Step.class);
+        Mockito.doThrow(new IllegalStateException("This step should not have been executed!")).when(onTrue).perform();
+        Step onFalse = Mockito.mock(Step.class);
+        Mockito.doNothing().when(onFalse).perform();
+
+        DeleteIndexCommandCheck dc = new DeleteIndexCommandCheck(
+            com, Mockito.mock(Logger.class), onTrue, onFalse
+        );
+        dc.perform();
+    }
 }

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/EnglishTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/EnglishTestCase.java
@@ -119,7 +119,7 @@ public class EnglishTestCase {
     public void knowsTheHelloResponse() {
         Language eng = new English();
         String hi = eng.response("hello.comment");
-        assertTrue(hi.contains("Hi, @%s! I can help you index your Github"));
+        assertTrue(hi.contains("Hi @%s! I can help you index your Github"));
     }
     
     /**

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/IndexPageaActionTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/IndexPageaActionTestCase.java
@@ -190,6 +190,7 @@ public class IndexPageaActionTestCase {
                     "@charlesmike index [this]("
                 )
         );
+        System.out.println( comments.get(1).json().getString("body"));
         assertTrue(
             comments.get(1).json().getString("body").endsWith(
                 "\n\nindex-page checks passed!"
@@ -456,6 +457,7 @@ public class IndexPageaActionTestCase {
          
          CommandedRepo crepo = Mockito.mock(CommandedRepo.class);
         Mockito.when(crepo.json()).thenReturn(repo);
+        Mockito.when(crepo.name()).thenReturn(repoName);
         Mockito.when(crepo.hasGhPagesBranch()).thenReturn(ghpages);
 
          Mockito.when(com.repo()).thenReturn(crepo);

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/IndexPageaActionTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/IndexPageaActionTestCase.java
@@ -259,7 +259,7 @@ public class IndexPageaActionTestCase {
     public void indexPageChecksFailAuthorNotOwner() throws Exception {
         Command com = this.mockCommand(
             "notowner", "amihaiemil", "amihaiemil.github.io",
-            false, false, "http://www.some.test/page/to/index"
+            false, false, "http://amihaiemil.github.io/page/to/index"
         );
         Language eng = this.mockEnglish(com);
         Brain br = new Brain(
@@ -302,7 +302,7 @@ public class IndexPageaActionTestCase {
     public void indexPageChecksFailRepoIsForked() throws Exception {
         Command com = this.mockCommand(
             "amihaiemil", "amihaiemil", "forkedrepo",
-            true, true, "http://www.some.test/page/to/index"
+            true, true, "http://amihaiemil.github.io/forkedrepo/page/to/index"
         );
         Language eng = this.mockEnglish(com);
         Brain br = new Brain(
@@ -325,6 +325,7 @@ public class IndexPageaActionTestCase {
                     "@charlesmike index [this]("
                 )
         );
+        System.out.println(comments.get(1).json().getString("body"));
         assertTrue(
             comments.get(1).json().getString("body").endsWith(
                 "\n\nrepo is a fork!"
@@ -342,7 +343,7 @@ public class IndexPageaActionTestCase {
     public void indexPageChecksFailNoWebsite() throws Exception {
         Command com = this.mockCommand(
             "amihaiemil", "amihaiemil", "someRepoWithNoWebsite",
-            false, false, "http://www.some.test/page/to/index"
+            false, false, "http://amihaiemil.github.io/page/to/index"
         );
         Language eng = this.mockEnglish(com);
         Brain br = new Brain(
@@ -365,6 +366,7 @@ public class IndexPageaActionTestCase {
                     "@charlesmike index [this]("
                 )
         );
+        System.out.println(comments.get(1).json().getString("body"));
         assertTrue(
             comments.get(1).json().getString("body").endsWith(
                 "\n\nThis repo doesn't host any website!"

--- a/charles-rest/src/test/java/com/amihaiemil/charles/github/PageHostedOnGithubCheckTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/github/PageHostedOnGithubCheckTestCase.java
@@ -159,7 +159,6 @@ public class PageHostedOnGithubCheckTestCase {
         String owner, String name, boolean hasGhPages, String link
     ) throws IOException {
         JsonObject repoJson = Json.createObjectBuilder()
-            .add("name", name)
             .add(
                 "owner",
                 Json.createObjectBuilder().add("login", owner).build()
@@ -168,6 +167,7 @@ public class PageHostedOnGithubCheckTestCase {
         Command com = Mockito.mock(Command.class);
         CommandedRepo crepo = Mockito.mock(CommandedRepo.class);
         Mockito.when(crepo.json()).thenReturn(repoJson);
+        Mockito.when(crepo.name()).thenReturn(name);
         Mockito.when(crepo.hasGhPagesBranch()).thenReturn(hasGhPages);
         
         

--- a/charles-rest/src/test/java/com/amihaiemil/charles/steps/SendEmailTestCase.java
+++ b/charles-rest/src/test/java/com/amihaiemil/charles/steps/SendEmailTestCase.java
@@ -1,5 +1,31 @@
+/*
+ * Copyright (c) 2016, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  1)Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *  2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *  3)Neither the name of charles-rest nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.charles.steps;
 
+
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -9,7 +35,6 @@ import javax.mail.internet.MimeMessage;
 
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -22,8 +47,6 @@ import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
 import com.jcabi.email.wire.SMTP;
-
-import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link SendEmail}


### PR DESCRIPTION
PR for #140 
Added flow to delete the repository.

Refactorings, especially the final reply logic, it is all pulled out in method ``Brain.finalCommentStep(...)`` and used everywhere. No more ``denialReply`` and ``followupSteps`` methods since they were code duplication.

Also, method ``Brain.withCommonChecks(...)`` adds the common checking steps for all the actions. 
