### PR TITLE
Fixed index checking logic + unit tests

### DIFF
--- a/src/main/java/com/amihaiemil/charles/aws/AmazonEsRepository.java
+++ b/src/main/java/com/amihaiemil/charles/aws/AmazonEsRepository.java
@@ -30,8 +30,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.http.HttpResponse;
 import com.amihaiemil.charles.DataExportException;
 import com.amihaiemil.charles.WebPage;
@@ -103,7 +107,15 @@ public final class AmazonEsRepository implements AwsEsRepository {
                     )
                 )
             );
-        return head.perform();
+        boolean exists = false;
+        try {
+            exists = head.perform();
+        } catch (AmazonServiceException ex) {
+            if (!(ex.getStatusCode() == HttpStatus.SC_NOT_FOUND)) {
+                throw ex;
+            }
+        }
+        return exists;
     }
     /**
      * Delete the elasticsearch index.

--- a/src/main/java/com/amihaiemil/charles/aws/SimpleAwsResponseHandler.java
+++ b/src/main/java/com/amihaiemil/charles/aws/SimpleAwsResponseHandler.java
@@ -25,6 +25,11 @@
  */
 package com.amihaiemil.charles.aws;
 
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.apache.commons.io.IOUtils;
+
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.http.HttpResponse;
 import com.amazonaws.http.HttpResponseHandler;
@@ -58,7 +63,15 @@ public class SimpleAwsResponseHandler implements
 
         int status = response.getStatusCode();
         if(status < 200 || status >= 300) {
-            AmazonServiceException ase = new AmazonServiceException("Unexpected status: " + status);
+            String content;
+            final StringWriter writer = new StringWriter();
+            try {
+                IOUtils.copy(response.getContent(), writer, "UTF-8");
+                content = writer.toString();
+            } catch (final IOException e) {
+            	content = "Couldn't get response content!";
+            }
+            AmazonServiceException ase = new AmazonServiceException(content);
             ase.setStatusCode(status);
             throw ase;
         }

--- a/src/main/java/com/amihaiemil/charles/github/Brain.java
+++ b/src/main/java/com/amihaiemil/charles/github/Brain.java
@@ -146,6 +146,7 @@ public class Brain {
          }
          return new Steps(
              steps,
+             this.logger,
              new SendReply(
                  new TextReply(
                      com,

--- a/src/main/java/com/amihaiemil/charles/github/Steps.java
+++ b/src/main/java/com/amihaiemil/charles/github/Steps.java
@@ -26,6 +26,8 @@
 
 package com.amihaiemil.charles.github;
 
+import org.slf4j.Logger;
+
 
 /**
  * Steps taken to fulfill a command.
@@ -46,12 +48,19 @@ public class Steps implements Step {
     private SendReply failureMessage;
     
     /**
+     * Action's logger.
+     */
+    private Logger logger;
+
+    /**
      * Constructor.
      * @param steps Given steps.
+     * @param log Given logger.
      * @param fm failure message in case any step fails.
      */
-    public Steps(Step steps, SendReply fm) {
+    public Steps(Step steps, Logger log, SendReply fm) {
         this.steps = steps;
+        this.logger = log;
         this.failureMessage = fm;
     }
 
@@ -71,6 +80,7 @@ public class Steps implements Step {
         try {
             this.steps.perform();
         } catch (RuntimeException ex) {
+            logger.error("A runtime exception occured", ex);
             this.failureMessage.perform();
         }
     }

--- a/src/main/resources/responses_en.properties
+++ b/src/main/resources/responses_en.properties
@@ -24,8 +24,8 @@ denied.deleteindex.comment=@%s the repository's name in a delete command has to 
                            and it has to match the actual reponame exactly (case sensitive) \n\n\
                            A valid delete command here is ``@%s delete `%s` index``.
 
-index.missing.comment=@%s there is no index for this repo, so your command\n\
-                      cannot be fulfilled. Either the index was removed already\n\
+index.missing.comment=@%s there is no index for this repo, so your command \
+                      cannot be fulfilled. Either the index was removed already \
                       following a ``delete`` command, or it has never existed.\n\n\
                       Check the [logs](%s) for more details.
 

--- a/src/test/java/com/amihaiemil/charles/aws/SimpleAwsResponseHandlerTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/aws/SimpleAwsResponseHandlerTestCase.java
@@ -72,11 +72,16 @@ public class SimpleAwsResponseHandlerTestCase {
     public void throwsAwsExceptionOnBadStatus() {
         HttpResponse response = Mockito.mock(HttpResponse.class);
         Mockito.when(response.getStatusCode()).thenReturn(HttpURLConnection.HTTP_BAD_METHOD);
+        String content = "bad request message";
+        Mockito.when(response.getContent())
+            .thenReturn(
+                new ByteArrayInputStream(content.getBytes())
+            );
         try {
             new SimpleAwsResponseHandler(true).handle(response);
             fail("AmazonServiceException should have been thrown!");
         } catch (AmazonServiceException awsEx) {
-               assertTrue(awsEx.getErrorMessage().equals("Unexpected status: 405"));
+            assertTrue(awsEx.getErrorMessage().equals(content));
             assertTrue(awsEx.getStatusCode() == HttpURLConnection.HTTP_BAD_METHOD);
         }
     }

--- a/src/test/java/com/amihaiemil/charles/github/StepsTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/StepsTestCase.java
@@ -57,7 +57,11 @@ public class StepsTestCase {
      */
     @Test
     public void stepsPerformOk() {
-        Steps steps = new Steps(Mockito.mock(Step.class), Mockito.mock(SendReply.class));
+        Steps steps = new Steps(
+            Mockito.mock(Step.class),
+            Mockito.mock(Logger.class),
+            Mockito.mock(SendReply.class)
+        );
         steps.perform();
     }
     
@@ -78,7 +82,7 @@ public class StepsTestCase {
         Mockito.doThrow(new IllegalStateException("for test"))
             .when(s).perform();
 
-        Steps steps = new Steps(s, sr);
+        Steps steps = new Steps(s, Mockito.mock(Logger.class), sr);
         steps.perform();
 
         List<Comment> comments = Lists.newArrayList(com.issue().comments().iterate());


### PR DESCRIPTION
PR for #171 
The problem was that aws-java-sdk routes 404 responses to the error handler directly, not to the response handler as I initially believed.

Also added unit tests.