### PR TITLE
Used encapsulated system properties for AWS layer

### DIFF
--- a/src/main/java/com/amihaiemil/charles/aws/AccessKeyId.java
+++ b/src/main/java/com/amihaiemil/charles/aws/AccessKeyId.java
@@ -32,5 +32,30 @@ package com.amihaiemil.charles.aws;
  * @since 1.0.0
  */
 public interface AccessKeyId extends SystemProperty {
+    
+    /**
+     * Actual name of the aws access key id sys prop.
+     */
+    String NAME = "aws.accessKeyId";
+    
+    /**
+     * Fake for unit testing.
+     */
+    public static final class Fake implements AccessKeyId {
 
+        private String value;
+        
+        public Fake() {
+            this("testAccessKeyId");
+        }
+        
+        public Fake(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String read() {
+            return this.value;
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/charles/aws/AmazonEsRepository.java
+++ b/src/main/java/com/amihaiemil/charles/aws/AmazonEsRepository.java
@@ -64,11 +64,45 @@ public final class AmazonEsRepository implements AwsEsRepository {
     private String indexName;
 
     /**
+     * AWS access key.
+     */
+    private AccessKeyId accesskey;
+    
+    /**
+     * Aws secret key;
+     */
+    private SecretKey secretKey;
+    
+    /**
+     * Aws ES region.
+     */
+    private Region reg;
+    
+    /**
+     * ElasticSearch URL.
+     */
+    private EsEndPoint esEdp;
+    
+    /**
      * ctor.
      * @param indexName Name of the Es index where the pages will be exported.
+     * @param accessKey Aws access key.
+     * @param secretKey Aws secret key.
+     * @param reg AWS ElasticSearch region.
+     * @param es ElasticSearch URL.
      */
-    public AmazonEsRepository(String indexName) {
+    public AmazonEsRepository(
+		final String indexName,
+		final AccessKeyId accesskey,
+        final SecretKey secretKey,
+        final Region reg,
+        final EsEndPoint es
+    ) {
         this.indexName = indexName;
+        this.accesskey = accesskey;
+        this.secretKey = secretKey;
+        this.reg = reg;
+        this.esEdp = es;
     }
 
     @Override
@@ -82,13 +116,17 @@ public final class AmazonEsRepository implements AwsEsRepository {
                     new AwsHttpHeaders<>(
                         new AwsPost<>(
                             new EsHttpRequest<>(
+                            	this.esEdp,
                                 "_bulk",
                                 new SimpleAwsResponseHandler(false),
                                 new SimpleAwsErrorHandler(false)
                             ),
                             new ByteArrayInputStream(data.getBytes())
                         ), headers
-                     )
+                     ),
+                     this.accesskey,
+                     this.secretKey,
+                     this.reg
                 );
                 index.perform();
         } catch (IOException e) {
@@ -108,11 +146,15 @@ public final class AmazonEsRepository implements AwsEsRepository {
             new SignedRequest<>(
                 new AwsHead<>(
                     new EsHttpRequest<>(
+                        this.esEdp,
                         this.indexName,
                         new BooleanAwsResponseHandler(),
                         new SimpleAwsErrorHandler(false)
                     )
-                )
+                ),
+                this.accesskey,
+                this.secretKey,
+                this.reg
             );
         boolean exists = false;
         try {
@@ -134,11 +176,15 @@ public final class AmazonEsRepository implements AwsEsRepository {
             new SignedRequest<>(
                 new AwsDelete<>(
                     new EsHttpRequest<>(
+                    	this.esEdp,
                         this.indexName,
                         new SimpleAwsResponseHandler(false),
                         new SimpleAwsErrorHandler(false)
                     )
-                )
+                ),
+                this.accesskey,
+                this.secretKey,
+                this.reg
            );
        deleteIndex.perform();
     }

--- a/src/main/java/com/amihaiemil/charles/aws/AmazonEsSearch.java
+++ b/src/main/java/com/amihaiemil/charles/aws/AmazonEsSearch.java
@@ -56,13 +56,45 @@ public final class AmazonEsSearch {
     private String indexName;
 
     /**
-     * Ctor.
-     * @param qry
-     * @param idxName
+     * ElasticSearch URL.
      */
-    public AmazonEsSearch(SearchQuery qry, String idxName) {
+    private EsEndPoint esEdp;
+
+    /**
+     * AWS access key.
+     */
+    private AccessKeyId accesskey;
+    
+    /**
+     * Aws secret key;
+     */
+    private SecretKey secretKey;
+    
+    /**
+     * Aws ES region.
+     */
+    private Region reg;
+    
+    /**
+     * Ctor.
+     * @param es ElasticSearch URL.
+     * @param qry Search query.
+     * @param idxName Index Name.
+     */
+    public AmazonEsSearch(
+        final EsEndPoint es,
+        final AccessKeyId accesskey,
+        final SecretKey secretKey,
+        final Region reg,
+        final SearchQuery qry,
+        final String idxName
+    ) {
+    	this.esEdp = es;
         this.query = qry;
         this.indexName = idxName;
+        this.accesskey = accesskey;
+        this.secretKey = secretKey;
+        this.reg = reg;
     }
 
     /**
@@ -77,12 +109,17 @@ public final class AmazonEsSearch {
     	        new AwsHttpHeaders<>(
     	            new AwsPost<>(
     	                new EsHttpRequest<>(
+    	                	this.esEdp,
     	            	    this.indexName + "/_search",
-    	                    new SearchResponseHandler(), new SimpleAwsErrorHandler(false)
+    	                    new SearchResponseHandler(),
+    	                    new SimpleAwsErrorHandler(false)
     	                ),
     	                new ByteArrayInputStream(this.query.toJson().toString().getBytes())
     	            ), headers
-    	        )
+    	        ),
+    	        this.accesskey,
+                this.secretKey,
+                this.reg
     	    );
         return search.perform();
     }

--- a/src/main/java/com/amihaiemil/charles/aws/EsEndPoint.java
+++ b/src/main/java/com/amihaiemil/charles/aws/EsEndPoint.java
@@ -33,4 +33,29 @@ package com.amihaiemil.charles.aws;
  */
 public interface EsEndPoint extends SystemProperty {
 
+    /**
+     * Actual name of the aws es endpoint sys prop.
+     */
+    String NAME = "aws.es.endpoint";
+    
+    /**
+     * Fake for unit testing.
+     */
+    public static final class Fake implements EsEndPoint {
+
+        private String value;
+        
+        public Fake() {
+            this("testAccessEsEndpoint");
+        }
+        
+        public Fake(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String read() {
+            return this.value;
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/charles/aws/Region.java
+++ b/src/main/java/com/amihaiemil/charles/aws/Region.java
@@ -26,12 +26,36 @@
 package com.amihaiemil.charles.aws;
 
 /**
- * AWS Region system property.
+ * AWS ElasticSearch Region system property.
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.0
  *
  */
 public interface Region extends SystemProperty {
+	/**
+     * Actual name of the aws ES region sys prop.
+     */
+    String NAME = "aws.es.region";
+    
+    /**
+     * Fake for unit testing.
+     */
+    public static final class Fake implements Region {
 
+        private String value;
+        
+        public Fake() {
+            this("testAwsEsRegion");
+        }
+        
+        public Fake(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String read() {
+            return this.value;
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/charles/aws/SecretKey.java
+++ b/src/main/java/com/amihaiemil/charles/aws/SecretKey.java
@@ -32,5 +32,29 @@ package com.amihaiemil.charles.aws;
  * @since 1.0.0
  */
 public interface SecretKey extends SystemProperty {
+	/**
+     * Actual name of the aws secret key sys prop.
+     */
+    String NAME = "aws.secretKey";
     
+    /**
+     * Fake for unit testing.
+     */
+    public static final class Fake implements SecretKey {
+
+        private String value;
+        
+        public Fake() {
+            this("testAwsSecretKey");
+        }
+        
+        public Fake(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String read() {
+            return this.value;
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/charles/aws/StAccessKeyId.java
+++ b/src/main/java/com/amihaiemil/charles/aws/StAccessKeyId.java
@@ -32,13 +32,12 @@ package com.amihaiemil.charles.aws;
  * @since 1.0.0
  */
 public final class StAccessKeyId extends AbstractSystemProperty implements AccessKeyId {
-    
-    /**
-     * Ctor. 
-     * @param String name
-     */
-    public StAccessKeyId(final String name) {
-        super(name);
+	
+	/**
+	 * Ctor.
+	 */
+    public StAccessKeyId() {
+        super(AccessKeyId.NAME);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/aws/StEsEndPoint.java
+++ b/src/main/java/com/amihaiemil/charles/aws/StEsEndPoint.java
@@ -35,18 +35,9 @@ public final class StEsEndPoint extends AbstractSystemProperty implements EsEndP
     
     /**
      * Ctor. 
-     * @param String name
      */
-    public StEsEndPoint(final String name) {
-        super(name);
+    public StEsEndPoint() {
+        super(EsEndPoint.NAME);
     }
  
-    @Override
-    public String read() {
-        String endPoint = super.read();
-        if(!endPoint.endsWith("/")) {
-            endPoint += "/";
-        }
-        return endPoint;
-    }
 }

--- a/src/main/java/com/amihaiemil/charles/aws/StRegion.java
+++ b/src/main/java/com/amihaiemil/charles/aws/StRegion.java
@@ -32,13 +32,12 @@ package com.amihaiemil.charles.aws;
  * @since 1.0.0
  */
 public final class StRegion extends AbstractSystemProperty implements Region {
-    
+
     /**
      * Ctor. 
-     * @param String name
      */
-    public StRegion(final String name) {
-        super(name);
+    public StRegion() {
+        super(Region.NAME);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/aws/StSecretKey.java
+++ b/src/main/java/com/amihaiemil/charles/aws/StSecretKey.java
@@ -32,13 +32,12 @@ package com.amihaiemil.charles.aws;
  * @since 1.0.0
  */
 public final class StSecretKey extends AbstractSystemProperty implements SecretKey {
-    
+
     /**
      * Ctor. 
-     * @param String name
      */
-    public StSecretKey(final String name) {
-        super(name);
+    public StSecretKey() {
+        super(SecretKey.NAME);
     }
-
+    
 }

--- a/src/main/java/com/amihaiemil/charles/aws/requests/EsHttpRequest.java
+++ b/src/main/java/com/amihaiemil/charles/aws/requests/EsHttpRequest.java
@@ -33,6 +33,8 @@ import com.amazonaws.Response;
 import com.amazonaws.http.AmazonHttpClient;
 import com.amazonaws.http.ExecutionContext;
 import com.amazonaws.http.HttpResponseHandler;
+import com.amihaiemil.charles.aws.EsEndPoint;
+
 import java.net.URI;
 
 /**
@@ -61,24 +63,24 @@ public final class EsHttpRequest<T> extends AwsHttpRequest<T> {
 
     /**
      * Ctor.
-     * @param uri REST path
+     * @param esEdp ElasticSearch URL.
+     * @param uri REST path to the desired ElasticSearch endpoint.
      * @param respHandler Response handler.
      * @param errHandle Error handler.
      */
     public EsHttpRequest(
+    	EsEndPoint esEdp,
         String uri,
         HttpResponseHandler<T> respHandler,
         HttpResponseHandler<AmazonServiceException> errHandler
     ){
     	this.request = new DefaultRequest<Void>("es");
-        String esEndpoint = System.getProperty("aws.es.endpoint");
+        String esEndpoint = esEdp.read();
         if(esEndpoint == null || esEndpoint.isEmpty()) {
             throw new IllegalStateException("ElasticSearch endpoint needs to be specified!");
-        }
-        if(esEndpoint.endsWith("/")) {
-            esEndpoint += uri;
-        } else {
-            esEndpoint += "/" + uri;
+        }        
+        if(!esEndpoint.endsWith("/")) {
+        	esEndpoint += "/";
         }
         this.request.setEndpoint(URI.create(esEndpoint));
         

--- a/src/main/java/com/amihaiemil/charles/github/DeleteIndex.java
+++ b/src/main/java/com/amihaiemil/charles/github/DeleteIndex.java
@@ -30,6 +30,10 @@ import java.io.IOException;
 import org.slf4j.Logger;
 
 import com.amihaiemil.charles.aws.AmazonEsRepository;
+import com.amihaiemil.charles.aws.StAccessKeyId;
+import com.amihaiemil.charles.aws.StEsEndPoint;
+import com.amihaiemil.charles.aws.StRegion;
+import com.amihaiemil.charles.aws.StSecretKey;
 
 /**
  * Step that deletes the index from AWS es.
@@ -55,7 +59,13 @@ public class DeleteIndex  extends IntermediaryStep {
     public void perform(Command command, Logger logger) throws IOException {
         logger.info("Starting index deletion...");
         try {
-            new AmazonEsRepository(command.indexName()).delete();
+            new AmazonEsRepository(
+                command.indexName(),
+                new StAccessKeyId(),
+                new StSecretKey(),
+                new StRegion(),
+                new StEsEndPoint()
+            ).delete();
         } catch (IOException e) {
             logger.error("Exception while deleting the index!", e);
             throw new IOException("Exception while deleting the index!" , e);

--- a/src/main/java/com/amihaiemil/charles/github/IndexExistsCheck.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexExistsCheck.java
@@ -28,6 +28,10 @@ package com.amihaiemil.charles.github;
 import org.slf4j.Logger;
 
 import com.amihaiemil.charles.aws.AmazonEsRepository;
+import com.amihaiemil.charles.aws.StAccessKeyId;
+import com.amihaiemil.charles.aws.StEsEndPoint;
+import com.amihaiemil.charles.aws.StRegion;
+import com.amihaiemil.charles.aws.StSecretKey;
 
 import java.io.IOException;
 
@@ -51,7 +55,17 @@ public final class IndexExistsCheck  extends PreconditionCheckStep {
      * @param onFalse the step to perform in unsuccessful check.
      */
     public IndexExistsCheck(String index, Step onTrue, Step onFalse) {
-        this(new AmazonEsRepository(index), onTrue, onFalse);
+    	
+        this(
+            new AmazonEsRepository(
+        		index,
+                new StAccessKeyId(),
+                new StSecretKey(),
+                new StRegion(),
+                new StEsEndPoint()
+            ),
+            onTrue, onFalse
+        );
     }
 
     /**

--- a/src/main/java/com/amihaiemil/charles/github/IndexPage.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexPage.java
@@ -36,6 +36,10 @@ import com.amihaiemil.charles.LiveWebPage;
 import com.amihaiemil.charles.SnapshotWebPage;
 import com.amihaiemil.charles.WebPage;
 import com.amihaiemil.charles.aws.AmazonEsRepository;
+import com.amihaiemil.charles.aws.StAccessKeyId;
+import com.amihaiemil.charles.aws.StEsEndPoint;
+import com.amihaiemil.charles.aws.StRegion;
+import com.amihaiemil.charles.aws.StSecretKey;
 
 /**
  * Step to index a single page.
@@ -64,9 +68,13 @@ public class IndexPage extends IndexStep {
              driver.get(link);
              WebPage snapshot = new SnapshotWebPage(new LiveWebPage(driver));
              logger.info("Page crawled. Sending to aws...");
-             new AmazonEsRepository(command.indexName()).export(
-                 Arrays.asList(snapshot)
-             );
+             new AmazonEsRepository(
+                 command.indexName(),
+                 new StAccessKeyId(),
+                 new StSecretKey(),
+                 new StRegion(),
+                 new StEsEndPoint()
+             ).export(Arrays.asList(snapshot));
              logger.info("Page successfully sent to aws!");
         } catch (
             final DataExportException | RuntimeException e

--- a/src/main/java/com/amihaiemil/charles/github/IndexSite.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSite.java
@@ -36,6 +36,10 @@ import com.amihaiemil.charles.IgnoredPatterns;
 import com.amihaiemil.charles.RetriableCrawl;
 import com.amihaiemil.charles.WebCrawl;
 import com.amihaiemil.charles.aws.AmazonEsRepository;
+import com.amihaiemil.charles.aws.StAccessKeyId;
+import com.amihaiemil.charles.aws.StEsEndPoint;
+import com.amihaiemil.charles.aws.StRegion;
+import com.amihaiemil.charles.aws.StSecretKey;
 
 /**
  * Step to index a website.
@@ -88,7 +92,14 @@ public class IndexSite extends IndexStep {
         + " .The website will be crawled as a graph, going in-depth from the index page.");
         WebCrawl siteCrawl = new GraphCrawl(
             siteIndexUrl, this.phantomJsDriver(), new IgnoredPatterns(),
-            new AmazonEsRepository(command.indexName()), 20
+            new AmazonEsRepository(
+                command.indexName(),
+                new StAccessKeyId(),
+                new StSecretKey(),
+                new StRegion(),
+                new StEsEndPoint()
+            ),
+            20
         );
         return new RetriableCrawl(siteCrawl, 5);
     }

--- a/src/main/java/com/amihaiemil/charles/github/IndexSitemap.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSitemap.java
@@ -26,12 +26,18 @@
 package com.amihaiemil.charles.github;
 
 import java.io.IOException;
+
 import org.slf4j.Logger;
+
 import com.amihaiemil.charles.DataExportException;
 import com.amihaiemil.charles.RetriableCrawl;
 import com.amihaiemil.charles.SitemapXmlCrawl;
 import com.amihaiemil.charles.WebCrawl;
 import com.amihaiemil.charles.aws.AmazonEsRepository;
+import com.amihaiemil.charles.aws.StAccessKeyId;
+import com.amihaiemil.charles.aws.StEsEndPoint;
+import com.amihaiemil.charles.aws.StRegion;
+import com.amihaiemil.charles.aws.StSecretKey;
 import com.amihaiemil.charles.sitemap.SitemapXmlOnline;
 
 /**
@@ -51,16 +57,22 @@ public class IndexSitemap extends IndexStep {
         super(next);
     }
 
-	@Override
-	public void perform(Command command, Logger logger) throws IOException {
-		String link = this.getLink(command);
+    @Override
+    public void perform(Command command, Logger logger) throws IOException {
+        String link = this.getLink(command);
         try {
-        	logger.info("Indexing sitemap " + link + " ...");
+            logger.info("Indexing sitemap " + link + " ...");
             WebCrawl sitemap = new RetriableCrawl(
                 new SitemapXmlCrawl(
                     this.phantomJsDriver(),
                     new SitemapXmlOnline(link),
-                    new AmazonEsRepository(command.indexName()),
+                    new AmazonEsRepository(
+                        command.indexName(),
+                        new StAccessKeyId(),
+                        new StSecretKey(),
+                        new StRegion(),
+                        new StEsEndPoint()
+                    ),
                     20
                 ),
                 5
@@ -76,9 +88,9 @@ public class IndexSitemap extends IndexStep {
            );
        }
        this.next().perform(command, logger);
-	}
+    }
 
-	/**
+    /**
      * Get the sitemap's link from the command's text which should
      * be in markdown format, with a link like
      * [this](http://link.com/here/the/ling) .

--- a/src/test/java/com/amihaiemil/charles/aws/requests/SignedRequestTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/aws/requests/SignedRequestTestCase.java
@@ -29,6 +29,9 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import com.amazonaws.Request;
+import com.amihaiemil.charles.aws.AccessKeyId;
+import com.amihaiemil.charles.aws.Region;
+import com.amihaiemil.charles.aws.SecretKey;
 
 /**
  * Unit tests for {@link SignedRequest}
@@ -44,7 +47,10 @@ public class SignedRequestTestCase {
     @Test
     public void fetchesOriginalRequest() {
         AwsHttpRequest<String> signed = new SignedRequest<>(
-            new AwsHttpRequest.FakeAwsHttpRequest()
+            new AwsHttpRequest.FakeAwsHttpRequest(),
+            new AccessKeyId.Fake("access_key"),
+            new SecretKey.Fake("secret"),
+            new Region.Fake("ro")
         );
         MatcherAssert.assertThat(
             signed.request(), Matchers.notNullValue()
@@ -60,12 +66,11 @@ public class SignedRequestTestCase {
      */
     @Test
     public void performsRequest() {
-        System.setProperty("aws.es.region", "test");
-        System.setProperty("aws.accessKeyId", "test");
-        System.setProperty("aws.secretKey", "test");
-
         AwsHttpRequest<String> signed = new SignedRequest<>(
-            new AwsHttpRequest.FakeAwsHttpRequest()
+            new AwsHttpRequest.FakeAwsHttpRequest(),
+            new AccessKeyId.Fake("access_key"),
+            new SecretKey.Fake("secret"),
+            new Region.Fake("ro")
         );
         MatcherAssert.assertThat(
             signed.perform(),


### PR DESCRIPTION
PR for #230 
AWS system properties are abstractized for easier testing. Tests do not have to set any aws system property anymore. See this post: http://www.amihaiemil.com/2017/02/24/each-system-property-a-class.html