### PR TITLE
LogsLocation as param of Knowledge.handle

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -45,23 +45,21 @@ First, the bot puts together all its knowledges, then it uses them to find the p
 the bot didn't manage to categorize the command and it will leave a Github reply informing the commander about the sitiuation:
 
 ```java
-    final Knowledge knowledge = new Conversation(//it can have a convesation
-        new Hello(//it can say hello
-            new IndexSiteKn(//it can index a site
-                this.logs,
-                new IndexSitemapKn(//it can index a site via a sitemap.xml
-                    this.logs,
-                    new IndexPageKn(//it can index a single page
-                        this.logs,
-                        new DeleteIndexKn(//it can delete the idnex
-                            this.logs,
-                            new Confused()//it can be confused (not understand the command)
+    final Knowledge knowledge = new Conversation(      //it has a conversation based on a command
+        new Hello(                                     //it can say hello
+            new IndexSiteKn(                           //it can index a whole website
+                new IndexSitemapKn(                    //it can index a site following a sitemap
+                    new IndexPageKn(                   //it can indes a single page
+                        new DeleteIndexKn(             //it can delete a whole index
+                            new DeletePageKn(          //it can delete a single page from an index
+                                new Confused()         //it may be confused, not understanding your command.
+                            )
                         )
                     )
                 )
             )
         )
-    )
+    );
 ```
 
 

--- a/architecture.md
+++ b/architecture.md
@@ -49,7 +49,7 @@ the bot didn't manage to categorize the command and it will leave a Github reply
         new Hello(                                     //it can say hello
             new IndexSiteKn(                           //it can index a whole website
                 new IndexSitemapKn(                    //it can index a site following a sitemap
-                    new IndexPageKn(                   //it can indes a single page
+                    new IndexPageKn(                   //it can index a single page
                         new DeleteIndexKn(             //it can delete a whole index
                             new DeletePageKn(          //it can delete a single page from an index
                                 new Confused()         //it may be confused, not understanding your command.

--- a/src/main/java/com/amihaiemil/charles/github/Action.java
+++ b/src/main/java/com/amihaiemil/charles/github/Action.java
@@ -89,28 +89,21 @@ public class Action {
             final Knowledge knowledge = new Conversation(
                 new Hello(
                     new IndexSiteKn(
-                        this.logs,
                         new IndexSitemapKn(
-                            this.logs,
                             new IndexPageKn(
-                                this.logs,
                                 new DeleteIndexKn(
-                                    this.logs,
                                     new DeletePageKn(
-                                        this.logs,
-                                        new Confused(this.logs)
+                                        new Confused()
                                     )
                                 )
                             )
                         )
-                    ),
-                    this.logs
+                    )
                 )
             );
             final Steps steps = knowledge.handle(
-                new ValidCommand(
-                    new LastComment(this.issue)
-                )
+                new ValidCommand(new LastComment(this.issue)),
+                this.logs
             );
             steps.perform(this.logger);
         } catch (final IllegalArgumentException e) {

--- a/src/main/java/com/amihaiemil/charles/github/Confused.java
+++ b/src/main/java/com/amihaiemil/charles/github/Confused.java
@@ -36,17 +36,8 @@ import java.io.IOException;
  */
 public class Confused implements Knowledge {
 
-	/**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
-    
-    public Confused(LogsLocation logsLoc) {
-    	this.logsLoc = logsLoc;
-    }
-	
     @Override
-    public Steps handle(Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         return new StepsTree(
             new SendReply(
 		        new TextReply(
@@ -56,7 +47,7 @@ public class Confused implements Knowledge {
 		                com.authorLogin()
 		            )
 		        ), new Step.FinalStep()
-		    ), com, this.logsLoc
+		    ), com, logs
         );
         		
     }

--- a/src/main/java/com/amihaiemil/charles/github/Conversation.java
+++ b/src/main/java/com/amihaiemil/charles/github/Conversation.java
@@ -64,7 +64,7 @@ public final class Conversation implements Knowledge {
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
     	String type = "unknown";
     	Command understood = new Understood(com, type, this.languages[0]);
         for(Language lang : this.languages) {
@@ -74,7 +74,7 @@ public final class Conversation implements Knowledge {
                 break;
             }
         }
-        return this.followup.handle(understood);
+        return this.followup.handle(understood, logs);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/github/DeleteIndexKn.java
+++ b/src/main/java/com/amihaiemil/charles/github/DeleteIndexKn.java
@@ -36,27 +36,20 @@ import java.io.IOException;
 public final class DeleteIndexKn implements Knowledge {
 
     /**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
-
-    /**
      * What do we do if it's not an 'deleteindex' command?
      */
     private Knowledge notDelete;
 
     /**
      * Ctor.
-     * @param logsLoc Location of the log file for the bot's action.
      * @param notDelete What do we do if it's not an 'deleteindex' command?
      */
-    public DeleteIndexKn(final LogsLocation logsLoc, final Knowledge notDelete) {
-        this.logsLoc = logsLoc;
+    public DeleteIndexKn(final Knowledge notDelete) {
         this.notDelete = notDelete;
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("deleteindex".equalsIgnoreCase(com.type())) {
             return new StepsTree(
 	            new DeleteIndexCommandCheck(
@@ -69,7 +62,7 @@ public final class DeleteIndexKn implements Knowledge {
 	                                    com,
 	                                    String.format(
 	                                        com.language().response("deleteindex.finished.comment"),
-	                                        com.authorLogin(), com.repo().name(), this.logsLoc.address()
+	                                        com.authorLogin(), com.repo().name(), logs.address()
 	                                    )
 	                                ),
 	                                new Follow(new Tweet(new Step.FinalStep()))
@@ -81,7 +74,7 @@ public final class DeleteIndexKn implements Knowledge {
 	                            com,
 	                            String.format(
 	                                com.language().response("index.missing.comment"),
-	                                com.authorLogin(), this.logsLoc.address()
+	                                com.authorLogin(), logs.address()
 	                            )
 	                        ),
 	                        new Step.FinalStep()
@@ -99,10 +92,10 @@ public final class DeleteIndexKn implements Knowledge {
 	                )
 	            ),
 	            com,
-	            this.logsLoc
+	            logs
 	        );
         }
-        return this.notDelete.handle(com);
+        return this.notDelete.handle(com, logs);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/github/DeletePageKn.java
+++ b/src/main/java/com/amihaiemil/charles/github/DeletePageKn.java
@@ -36,27 +36,20 @@ import java.io.IOException;
 public final class DeletePageKn implements Knowledge {
 
     /**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
-
-    /**
      * What do we do if it's not an 'deletepage' command?
      */
     private Knowledge notDeletePage;
     
     /**
      * Ctor.
-     * @param logsLoc Location of the log file for the bot's action.
      * @param notDeletePage What do we do if it's not an 'deletepage' command?
      */
-    public DeletePageKn(final LogsLocation logsLoc, final Knowledge notDeletePage) {
-        this.logsLoc = logsLoc;
+    public DeletePageKn(final Knowledge notDeletePage) {
         this.notDeletePage = notDeletePage;
     }
     
     @Override
-    public Steps handle(Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("deletepage".equalsIgnoreCase(com.type())) {
             return new StepsTree(
                 new IndexExistsCheck(
@@ -68,7 +61,7 @@ public final class DeletePageKn implements Knowledge {
                                     com,
                                     String.format(
                                         com.language().response("deletepage.finished.comment"),
-                                        com.authorLogin(), this.logsLoc.address()
+                                        com.authorLogin(), logs.address()
                                     )
                                 ),
                                 new Follow(new Step.FinalStep())
@@ -80,17 +73,17 @@ public final class DeletePageKn implements Knowledge {
                             com,
                             String.format(
                                 com.language().response("index.missing.comment"),
-                                com.authorLogin(), this.logsLoc.address()
+                                com.authorLogin(), logs.address()
                             )
                         ),
                         new Step.FinalStep()
                     )
                 ),
                 com,
-                this.logsLoc
+                logs
             );
         }
-        return this.notDeletePage.handle(com);
+        return this.notDeletePage.handle(com, logs);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/github/Hello.java
+++ b/src/main/java/com/amihaiemil/charles/github/Hello.java
@@ -39,20 +39,17 @@ public final class Hello implements Knowledge {
      * What do we do if it's not a 'hello' command?
      */
     private Knowledge notHello;
-
-    private LogsLocation logsLoc;
     
     /**
      * Ctor.
      * @param notHello What do we do if it's not a 'hello' command?
      */
-    public Hello(final Knowledge notHello, final LogsLocation logs) {
+    public Hello(final Knowledge notHello) {
         this.notHello = notHello;
-        this.logsLoc = logs;
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("hello".equalsIgnoreCase(com.type())) {
             String hello = String.format(
                 com.language().response("hello.comment"),
@@ -64,9 +61,9 @@ public final class Hello implements Knowledge {
                     new Follow(new Step.FinalStep())
                 ),
                 com,
-                this.logsLoc
+                logs
             );
         }
-        return this.notHello.handle(com);
+        return this.notHello.handle(com, logs);
     }
 }

--- a/src/main/java/com/amihaiemil/charles/github/IndexPageKn.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexPageKn.java
@@ -36,27 +36,20 @@ import java.io.IOException;
 public final class IndexPageKn implements Knowledge {
 
     /**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
-
-    /**
      * What do we do if it's not an 'indexpage' command?
      */
     private Knowledge notIdxPage;
 
     /**
      * Ctor.
-     * @param logsLoc Location of the log file for the bot's action.
      * @param notIdxPage What do we do if it's not an 'indexpage' command?
      */
-    public IndexPageKn(final LogsLocation logsLoc, final Knowledge notIdxPage) {
-        this.logsLoc = logsLoc;
+    public IndexPageKn(final Knowledge notIdxPage) {
         this.notIdxPage = notIdxPage;
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("indexpage".equalsIgnoreCase(com.type())) {
             return new StepsTree(
             	new PageHostedOnGithubCheck(
@@ -67,7 +60,7 @@ public final class IndexPageKn implements Knowledge {
 	                            String.format(
 	                                com.language().response("index.start.comment"),
 	                                com.authorLogin(),
-	                                this.logsLoc.address()
+	                                logs.address()
 	                            )
 	                        ),
 	                        new IndexPage(
@@ -77,7 +70,7 @@ public final class IndexPageKn implements Knowledge {
 	                                        com,
 	                                        String.format(
 	                                            com.language().response("index.finished.comment"),
-	                                            com.authorLogin(), this.logsLoc.address()
+	                                            com.authorLogin(), logs.address()
 	                                        )
 	                                    ),
 	                                    new Follow(new Tweet(new Step.FinalStep()))
@@ -98,10 +91,10 @@ public final class IndexPageKn implements Knowledge {
 	                )
                 ),
                 com,
-                this.logsLoc
+                logs
             );
         }
-        return this.notIdxPage.handle(com);
+        return this.notIdxPage.handle(com, logs);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/github/IndexSiteKn.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSiteKn.java
@@ -36,27 +36,20 @@ import java.io.IOException;
 public final class IndexSiteKn implements Knowledge {
 
     /**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
-
-    /**
      * What do we do if it's not an 'indexsite' command?
      */
     private Knowledge notIdxSite;
 
     /**
      * Ctor.
-     * @param logsLoc Location of the log file for the bot's action.
      * @param notIdxSite What do we do if it's not an 'indexsite' command?
      */
-    public IndexSiteKn(final LogsLocation logsLoc, final Knowledge notIdxSite) {
-        this.logsLoc = logsLoc;
+    public IndexSiteKn(final Knowledge notIdxSite) {
         this.notIdxSite = notIdxSite;
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("indexsite".equalsIgnoreCase(com.type())) {
             return new StepsTree(
                 new GeneralPreconditionsCheck(
@@ -66,7 +59,7 @@ public final class IndexSiteKn implements Knowledge {
 		                    String.format(
 		                        com.language().response("index.start.comment"),
 		                        com.authorLogin(),
-		                        this.logsLoc.address()
+		                        logs.address()
 		                    )
 		                ),
 		                new IndexSite(
@@ -76,7 +69,7 @@ public final class IndexSiteKn implements Knowledge {
 		                                com,
 		                                String.format(
 		                                    com.language().response("index.finished.comment"),
-		                                    com.authorLogin(), this.logsLoc.address()
+		                                    com.authorLogin(), logs.address()
 		                                )
 		                            ),
 		                            new Follow(new Tweet(new Step.FinalStep()))
@@ -86,10 +79,10 @@ public final class IndexSiteKn implements Knowledge {
 		            )
                 ),
                 com,
-                this.logsLoc
+                logs
             );
         }
-        return this.notIdxSite.handle(com);
+        return this.notIdxSite.handle(com, logs);
     }
 
 }

--- a/src/main/java/com/amihaiemil/charles/github/IndexSitemapKn.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSitemapKn.java
@@ -34,11 +34,6 @@ import java.io.IOException;
  * @since 1.0.1
  */
 public final class IndexSitemapKn implements Knowledge {
-    
-    /**
-     * Location of the log file.
-     */
-    private LogsLocation logsLoc;
 
     /**
      * What do we do if it's not an 'indexsitemap' command?
@@ -47,16 +42,14 @@ public final class IndexSitemapKn implements Knowledge {
 
     /**
      * Ctor.
-     * @param logsLoc Location of the log file for the bot's action.
      * @param notIdxSitemap What do we do if it's not an 'indexpage' command?
      */
-    public IndexSitemapKn(final LogsLocation logsLoc, final Knowledge notIdxSitemap) {
-        this.logsLoc = logsLoc;
+    public IndexSitemapKn(final Knowledge notIdxSitemap) {
         this.notIdxSitemap = notIdxSitemap;
     }
 
     @Override
-    public Steps handle(final Command com) throws IOException {
+    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
         if("indexsitemap".equalsIgnoreCase(com.type())) {
             return new StepsTree(
             	new PageHostedOnGithubCheck(
@@ -66,7 +59,7 @@ public final class IndexSitemapKn implements Knowledge {
 	                            com,
 	                            String.format(
 	                                com.language().response("index.start.comment"),
-	                                com.authorLogin(), this.logsLoc.address()
+	                                com.authorLogin(), logs.address()
 	                            )
 	                        ),
 	                        new IndexSitemap(
@@ -76,7 +69,7 @@ public final class IndexSitemapKn implements Knowledge {
 	                                        com,
 	                                        String.format(
 	                                            com.language().response("index.finished.comment"),
-	                                            com.authorLogin(), this.logsLoc.address()
+	                                            com.authorLogin(), logs.address()
 	                                        )
 	                                    ),
 	                                    new Follow(new Tweet(new Step.FinalStep()))
@@ -97,9 +90,9 @@ public final class IndexSitemapKn implements Knowledge {
 	                )
                 ),
                 com,
-                this.logsLoc
+                logs
             );
         }
-        return this.notIdxSitemap.handle(com);
+        return this.notIdxSitemap.handle(com, logs);
     }
 }

--- a/src/main/java/com/amihaiemil/charles/github/Knowledge.java
+++ b/src/main/java/com/amihaiemil/charles/github/Knowledge.java
@@ -38,9 +38,10 @@ public interface Knowledge {
     /**
      * Handle the command somehow.
      * @param com Given command.
+     * @param logs Location of the log file.
      * @return Steps to fulfill the command.
      * @throws IOException If there's an IO problem,
      *  like comunicating with the Github API.
      */
-    Steps handle(final Command com) throws IOException;
+    Steps handle(final Command com, final LogsLocation logs) throws IOException;
 }

--- a/src/test/java/com/amihaiemil/charles/github/ConfusedTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/ConfusedTestCase.java
@@ -49,9 +49,9 @@ public class ConfusedTestCase {
         Mockito.when(com.authorLogin()).thenReturn("amihaiemil");
         Mockito.when(com.language()).thenReturn(new English());
 
-        final Knowledge confused = new Confused(Mockito.mock(LogsLocation.class));
+        final Knowledge confused = new Confused();
 
-        Steps steps = confused.handle(com);
+        Steps steps = confused.handle(com, Mockito.mock(LogsLocation.class));
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(
             steps instanceof StepsTree, Matchers.is(true)

--- a/src/test/java/com/amihaiemil/charles/github/ConversationTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/ConversationTestCase.java
@@ -29,6 +29,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import java.io.IOException;
 
 /**
@@ -57,7 +58,7 @@ public final class ConversationTestCase {
         final Knowledge conversation = new Conversation(
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("yes")
@@ -66,7 +67,7 @@ public final class ConversationTestCase {
                 }
             }, english, french
         );
-        conversation.handle(com);
+        conversation.handle(com, Mockito.mock(LogsLocation.class));
     }
 
     /**
@@ -87,7 +88,7 @@ public final class ConversationTestCase {
         final Knowledge conversation = new Conversation(
                 new Knowledge() {
                     @Override
-                    public Steps handle(final Command com) throws IOException {
+                    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                         MatcherAssert.assertThat(
                                 com.type(),
                                 Matchers.equalTo("oui")
@@ -96,7 +97,7 @@ public final class ConversationTestCase {
                     }
                 }, english, french
         );
-        conversation.handle(com);
+        conversation.handle(com, Mockito.mock(LogsLocation.class));
     }
 
     /**
@@ -115,7 +116,7 @@ public final class ConversationTestCase {
         final Knowledge conversation = new Conversation(
                 new Knowledge() {
                     @Override
-                    public Steps handle(final Command com) throws IOException {
+                    public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                         MatcherAssert.assertThat(
                                 com.type(),
                                 Matchers.equalTo("unknown")
@@ -124,6 +125,6 @@ public final class ConversationTestCase {
                     }
                 }, english
         );
-        conversation.handle(com);
+        conversation.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/DeleteIndexKnTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/DeleteIndexKnTestCase.java
@@ -26,6 +26,7 @@
 package com.amihaiemil.charles.github;
 
 import java.io.IOException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -57,10 +58,9 @@ public final class DeleteIndexKnTestCase {
         Mockito.when(logs.address()).thenReturn("/path/to/logs");
         
         final Knowledge deleteindex = new DeleteIndexKn(
-            logs,
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'deleteindex' command was misunderstood!"
                     );
@@ -68,7 +68,7 @@ public final class DeleteIndexKnTestCase {
             }
         );
 
-        Steps steps = deleteindex.handle(com);
+        Steps steps = deleteindex.handle(com, logs);
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(steps instanceof StepsTree, Matchers.is(true));
     }
@@ -83,10 +83,9 @@ public final class DeleteIndexKnTestCase {
         Mockito.when(com.type()).thenReturn("indexsite");
         
         final Knowledge deleteindex = new DeleteIndexKn(
-            Mockito.mock(LogsLocation.class),
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("indexsite")
@@ -95,6 +94,6 @@ public final class DeleteIndexKnTestCase {
                 }
             }
         );
-        deleteindex.handle(com);
+        deleteindex.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/DeletePageKnTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/DeletePageKnTestCase.java
@@ -26,6 +26,7 @@
 package com.amihaiemil.charles.github;
 
 import java.io.IOException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -54,10 +55,9 @@ public class DeletePageKnTestCase {
         Mockito.when(logs.address()).thenReturn("/path/to/logs");
         
         final Knowledge deletepage = new DeletePageKn(
-            logs,
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'deletepage' command was misunderstood!"
                     );
@@ -65,7 +65,7 @@ public class DeletePageKnTestCase {
             }
         );
 
-        Steps steps = deletepage.handle(com);
+        Steps steps = deletepage.handle(com, logs);
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(steps instanceof StepsTree, Matchers.is(true));
     }
@@ -80,10 +80,9 @@ public class DeletePageKnTestCase {
         Mockito.when(com.type()).thenReturn("indexsite");
         
         final Knowledge deletepage = new DeletePageKn(
-            Mockito.mock(LogsLocation.class),
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("indexsite")
@@ -92,6 +91,6 @@ public class DeletePageKnTestCase {
                 }
             }
         );
-        deletepage.handle(com);
+        deletepage.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/HelloTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/HelloTestCase.java
@@ -54,15 +54,15 @@ public final class HelloTestCase {
         final Knowledge hello = new Hello(
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'hello' command was misunderstood!"
                     );
                 }
-            }, Mockito.mock(LogsLocation.class)
+            }
         );
 
-        Steps steps = hello.handle(com);
+        Steps steps = hello.handle(com, Mockito.mock(LogsLocation.class));
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(
             steps instanceof StepsTree, Matchers.is(true)
@@ -81,15 +81,15 @@ public final class HelloTestCase {
         final Knowledge hello = new Hello(
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("indexsite")
                     );
                     return null;
                 }
-            }, Mockito.mock(LogsLocation.class)
+            }
         );
-        hello.handle(com);
+        hello.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/IndexPageKnTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/IndexPageKnTestCase.java
@@ -55,10 +55,9 @@ public final class IndexPageKnTestCase {
         Mockito.when(logs.address()).thenReturn("/path/to/logs");
         
         final Knowledge indexpage = new IndexPageKn(
-            logs,
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'indexpage' command was misunderstood!"
                     );
@@ -66,7 +65,7 @@ public final class IndexPageKnTestCase {
             }
         );
 
-        Steps steps = indexpage.handle(com);
+        Steps steps = indexpage.handle(com, logs);
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(
             steps instanceof StepsTree, Matchers.is(true)
@@ -83,10 +82,9 @@ public final class IndexPageKnTestCase {
         Mockito.when(com.type()).thenReturn("sitemap");
         
         final Knowledge indexpage = new IndexPageKn(
-            Mockito.mock(LogsLocation.class),
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("sitemap")
@@ -95,6 +93,6 @@ public final class IndexPageKnTestCase {
                 }
             }
         );
-        indexpage.handle(com);
+        indexpage.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/IndexSiteKnTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/IndexSiteKnTestCase.java
@@ -55,10 +55,9 @@ public final class IndexSiteKnTestCase {
         Mockito.when(logs.address()).thenReturn("/path/to/logs");
         
         final Knowledge indexsite = new IndexSiteKn(
-            logs,
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'indexsite' command was misunderstood!"
                     );
@@ -66,7 +65,7 @@ public final class IndexSiteKnTestCase {
             }
         );
 
-        Steps steps = indexsite.handle(com);
+        Steps steps = indexsite.handle(com, logs);
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(steps instanceof StepsTree, Matchers.is(true));
     }
@@ -81,10 +80,9 @@ public final class IndexSiteKnTestCase {
         Mockito.when(com.type()).thenReturn("hello");
         
         final Knowledge indexsite = new IndexSiteKn(
-            Mockito.mock(LogsLocation.class),
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("hello")
@@ -93,6 +91,6 @@ public final class IndexSiteKnTestCase {
                 }
             }
         );
-        indexsite.handle(com);
+        indexsite.handle(com, Mockito.mock(LogsLocation.class));
     }
 }

--- a/src/test/java/com/amihaiemil/charles/github/IndexSitemapKnTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/IndexSitemapKnTestCase.java
@@ -55,10 +55,9 @@ public final class IndexSitemapKnTestCase {
         Mockito.when(logs.address()).thenReturn("/path/to/logs");
         
         final Knowledge indexsitemap = new IndexSitemapKn(
-            logs,
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     throw new IllegalStateException(
                         "'indexsitemap' command was misunderstood!"
                     );
@@ -66,7 +65,7 @@ public final class IndexSitemapKnTestCase {
             }
         );
 
-        Steps steps = indexsitemap.handle(com);
+        Steps steps = indexsitemap.handle(com, logs);
         MatcherAssert.assertThat(steps, Matchers.notNullValue());
         MatcherAssert.assertThat(
             steps instanceof StepsTree, Matchers.is(true)
@@ -83,10 +82,9 @@ public final class IndexSitemapKnTestCase {
         Mockito.when(com.type()).thenReturn("unknwon");
         
         final Knowledge indexsitemap = new IndexSitemapKn(
-            Mockito.mock(LogsLocation.class),
             new Knowledge() {
                 @Override
-                public Steps handle(final Command com) throws IOException {
+                public Steps handle(final Command com, final LogsLocation logs) throws IOException {
                     MatcherAssert.assertThat(
                         com.type(),
                         Matchers.equalTo("unknwon")
@@ -95,6 +93,6 @@ public final class IndexSitemapKnTestCase {
                 }
             }
         );
-        indexsitemap.handle(com);
+        indexsitemap.handle(com, Mockito.mock(LogsLocation.class));
     }
 }


### PR DESCRIPTION
PR for #265 
LogsLocation is passed via the handle method, rather than the ctor. 
Instantiation of the overal Knowledge is also prettier now. 