### PR TITLE
Added ChromeDriver option

### DIFF
--- a/src/main/java/com/amihaiemil/charles/github/CharlesYml.java
+++ b/src/main/java/com/amihaiemil/charles/github/CharlesYml.java
@@ -50,9 +50,15 @@ public interface CharlesYml {
     boolean tweet();
 
     /**
+     * Driver to use (phantomjs, chrome etc).
+     * @return String driver.
+     */
+    String driver();
+
+    /**
      * Default .charles.yml file.
      */
-    public static final class Default implements CharlesYml {
+    final class Default implements CharlesYml {
         @Override
         public List<String> commanders() {
             return new ArrayList<>();
@@ -61,6 +67,11 @@ public interface CharlesYml {
         @Override
         public boolean tweet() {
             return false;
+        }
+
+        @Override
+        public String driver() {
+            return "chrome";
         }
     }
     

--- a/src/main/java/com/amihaiemil/charles/github/CharlesYmlInput.java
+++ b/src/main/java/com/amihaiemil/charles/github/CharlesYmlInput.java
@@ -49,7 +49,7 @@ public final class CharlesYmlInput implements CharlesYml {
 
     /**
      * Ctor.
-     * @param cyml .charles.yml.
+     * @param yaml .charles.yml.
      * @throws IOException If the input stream cannot be read.
      */
     public CharlesYmlInput(final InputStream yaml) throws IOException {
@@ -73,4 +73,13 @@ public final class CharlesYmlInput implements CharlesYml {
         return Boolean.valueOf(this.yaml.string("tweet"));
     }
 
+    @Override
+    public String driver() {
+        final String driver = this.yaml.string("driver");
+        if(driver != null) {
+            return driver;
+        } else {
+            return "chrome";
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/charles/github/IndexPage.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexPage.java
@@ -59,8 +59,15 @@ public class IndexPage extends IndexStep {
          String link = this.getLink(command);
          logger.info("Indexing page " + link + " ...");
          try {
+             final String specified = command.repo().charlesYml().driver();
+             logger.info("Crawling with the " + specified + " driver.");
+             final WebDriver driver;
+             if("phantomjs".equalsIgnoreCase(specified)) {
+                 driver = this.phantomJsDriver();
+             } else {
+                 driver = this.chromeDriver();
+             }
              logger.info("Crawling the page...");
-             WebDriver driver = this.phantomJsDriver();
              driver.get(link);
              WebPage snapshot = new SnapshotWebPage(new LiveWebPage(driver));
              logger.info("Page crawled. Sending to aws...");

--- a/src/main/java/com/amihaiemil/charles/github/IndexSite.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSite.java
@@ -28,6 +28,7 @@ package com.amihaiemil.charles.github;
 
 import java.io.IOException;
 
+import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 
 import com.amihaiemil.charles.DataExportException;
@@ -84,10 +85,21 @@ public class IndexSite extends IndexStep {
         } else {
             siteIndexUrl = "http://" + repoName;
         }
+
+        final String specified = command.repo().charlesYml().driver();
+        logger.info("Crawling with the " + specified + " driver.");
+        final WebDriver driver;
+        if("phantomjs".equalsIgnoreCase(specified)) {
+            driver = this.phantomJsDriver();
+        } else {
+            driver = this.chromeDriver();
+        }
+
         logger.info("Graph-crawling, starting from " + siteIndexUrl
         + " .The website will be crawled as a graph, going in-depth from the index page.");
+
         WebCrawl siteCrawl = new GraphCrawl(
-            siteIndexUrl, this.phantomJsDriver(), new IgnoredPatterns(),
+            siteIndexUrl, driver, new IgnoredPatterns(),
             new AmazonElasticSearch(command.indexName()),
             20
         );

--- a/src/main/java/com/amihaiemil/charles/github/IndexSitemap.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexSitemap.java
@@ -27,6 +27,7 @@ package com.amihaiemil.charles.github;
 
 import java.io.IOException;
 
+import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 
 import com.amihaiemil.charles.DataExportException;
@@ -57,10 +58,19 @@ public class IndexSitemap extends IndexStep {
     public void perform(Command command, Logger logger) throws IOException {
         String link = this.getLink(command);
         try {
+            final String specified = command.repo().charlesYml().driver();
+            logger.info("Crawling with the " + specified + " driver.");
+            final WebDriver driver;
+            if("phantomjs".equalsIgnoreCase(specified)) {
+                driver = this.phantomJsDriver();
+            } else {
+                driver = this.chromeDriver();
+            }
+
             logger.info("Indexing sitemap " + link + " ...");
             WebCrawl sitemap = new RetriableCrawl(
                 new SitemapXmlCrawl(
-                    this.phantomJsDriver(),
+                    driver,
                     new SitemapXmlOnline(link),
                     new AmazonElasticSearch(command.indexName()),
                     20

--- a/src/main/java/com/amihaiemil/charles/github/IndexStep.java
+++ b/src/main/java/com/amihaiemil/charles/github/IndexStep.java
@@ -26,6 +26,8 @@
 package com.amihaiemil.charles.github;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
@@ -50,7 +52,7 @@ public abstract class IndexStep extends IntermediaryStep{
 
     /**
      * Use phantomjs to fetch the web content.
-     * @return
+     * @return WebDriver.
      */
     protected WebDriver phantomJsDriver() {
         String phantomJsExecPath =  System.getProperty("phantomjsExec");
@@ -65,6 +67,27 @@ public abstract class IndexStep extends IntermediaryStep{
         );
         return new PhantomJSDriver(dc);
     }
+
+    /**
+     * Use Google Chrome headless to fetch the content.
+     * @return WebDriver.
+     */
+    protected WebDriver chromeDriver() {
+        final ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.setBinary("/usr/bin/google-chrome-stable");
+        chromeOptions.addArguments("--headless");
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--ignore-certificate-errors");
+
+        final DesiredCapabilities dc = new DesiredCapabilities();
+        dc.setJavascriptEnabled(true);
+        dc.setCapability(
+            ChromeOptions.CAPABILITY, chromeOptions
+        );
+        WebDriver chrome = new ChromeDriver(dc);
+        return chrome;
+    }
+
 
     /**
      * Use firefox to fetch web content.

--- a/src/test/java/com/amihaiemil/charles/github/CharlesYmlInputTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/github/CharlesYmlInputTestCase.java
@@ -97,4 +97,38 @@ public final class CharlesYmlInputTestCase {
         );
         MatcherAssert.assertThat(charles.tweet(), Matchers.is(true));
     }
+
+    /**
+     * CharlesYmlInput can read the specified driver.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsDriver() throws IOException {
+        final CharlesYml charles = new CharlesYmlInput(
+            new ByteArrayInputStream(
+                "commanders:\n  - charlesmike\n  - amihaiemil\ndriver: phantomjs"
+                .getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            charles.driver(), Matchers.equalTo("phantomjs")
+        );
+    }
+
+    /**
+     * CharlesYmlInput can read the default driver if it's not specified.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsDefaultDriver() throws IOException {
+        final CharlesYml charles = new CharlesYmlInput(
+            new ByteArrayInputStream(
+                "commanders:\n  - charlesmike\n  - amihaiemil\ntweet: true"
+                .getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            charles.driver(), Matchers.equalTo("chrome")
+        );
+    }
 }


### PR DESCRIPTION
Fixes #277 

``index-site`` and ``index-page`` are working properly now but, for some reason, ``index-sitemap`` is still broken. 

Solution: added option to crawl via Google Chrome headless because phantomjs could not ignore the unknown SSL certificates (since Github introduced HTTPS for custom domains, phantom stopped trusting those address). 

However, it's still possible to use the phantomjs crawl via the ``driver: phantomjs | chrome`` option configurable in ``.charles.yml``